### PR TITLE
Add simple LinkedIn formatting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# LinkedIn Post Formatter
+
+This repository contains a simple utility to convert Markdown-style `**bold**` and `*italic*` text into the Unicode characters supported by LinkedIn posts. The formatted text is copied to the macOS clipboard and saved as a `.txt` file.
+
+## Usage
+1. Ensure you are running on macOS so the `pbcopy` command is available.
+2. Edit `format_to_clipboard.py` and update `POST_DRAFT` with the content of your LinkedIn post.
+3. Run the script:
+   ```bash
+   python3 format_to_clipboard.py
+   ```
+4. The formatted post will be placed in the system clipboard and saved in a text file. The filename is derived from the first paragraph of your post.
+
+The conversion mappings are implemented in `linkedin_formatter.py`.

--- a/format_to_clipboard.py
+++ b/format_to_clipboard.py
@@ -1,0 +1,32 @@
+import subprocess
+from pathlib import Path
+from linkedin_formatter import convert_markdown_to_linkedin_unicode
+
+POST_DRAFT = """Hey everyone,
+I’m excited about **our new launch** next week—*stay tuned*!"""
+
+
+def save_to_clipboard(text: str) -> None:
+    try:
+        p = subprocess.run(['pbcopy'], input=text.encode('utf-8'), check=True)
+    except FileNotFoundError:
+        print('pbcopy not found. This script must be run on macOS to copy to clipboard.')
+
+
+def sanitize_filename(title: str) -> str:
+    sanitized = ''.join(ch if ch.isalnum() or ch == ' ' else '' for ch in title)
+    sanitized = '_'.join(sanitized.strip().split())
+    return sanitized[:50] if len(sanitized) > 50 else sanitized
+
+
+def main() -> None:
+    formatted = convert_markdown_to_linkedin_unicode(POST_DRAFT)
+    save_to_clipboard(formatted)
+
+    first_paragraph = POST_DRAFT.split("\n\n", 1)[0]
+    filename = sanitize_filename(first_paragraph) or 'post'
+    Path(f"{filename}.txt").write_text(formatted, encoding='utf-8')
+
+
+if __name__ == '__main__':
+    main()

--- a/linkedin_formatter.py
+++ b/linkedin_formatter.py
@@ -1,0 +1,22 @@
+import re
+
+BOLD_MAP = {
+    **{chr(i): chr(0x1D400 + i - 65) for i in range(65, 91)},
+    **{chr(i): chr(0x1D41A + i - 97) for i in range(97, 123)},
+}
+
+ITALIC_MAP = {
+    **{chr(i): chr(0x1D434 + i - 65) for i in range(65, 91)},
+    **{chr(i): chr(0x1D44E + i - 97) for i in range(97, 123)},
+}
+
+def convert_markdown_to_linkedin_unicode(text: str) -> str:
+    def bold_repl(match: re.Match) -> str:
+        return ''.join(BOLD_MAP.get(ch, ch) for ch in match.group(1))
+
+    def italic_repl(match: re.Match) -> str:
+        return ''.join(ITALIC_MAP.get(ch, ch) for ch in match.group(1))
+
+    text = re.sub(r"\*\*(.+?)\*\*", bold_repl, text)
+    text = re.sub(r"\*(.+?)\*", italic_repl, text)
+    return text


### PR DESCRIPTION
## Summary
- implement conversion helper `linkedin_formatter.py`
- add `format_to_clipboard.py` to copy the converted post to the macOS clipboard and save a text file
- document usage in `README.md`

## Testing
- `python3 -m py_compile linkedin_formatter.py format_to_clipboard.py 'Conversion Function' 'Publish Function' 'Page Object Model Class' 'Scheduling with schedule'`

------
https://chatgpt.com/codex/tasks/task_e_6871967c49dc833083c82551d43f7f54