### PR TITLE
Improve clipboard usage for LinkedIn formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# LinkedIn Post Formatter
+
+This small script converts Markdown-style `**bold**` and `*italic*` (or `_italic_`) markers into the Unicode characters recommended in the [LinkedIn post formatting guide](https://reply.io/blog/linkedin-post-formatting/). After formatting, the post is copied to the macOS clipboard (requires `pyperclip`) and saved to a `.txt` file named after the first paragraph of the post.
+
+## Setup
+
+1. Install Python 3 if it's not already available.
+2. Install dependencies:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Usage
+
+1. Copy your LinkedIn post draft to the clipboard.
+2. Run the script:
+
+   ```bash
+   python format_linkedin_post.py
+   ```
+
+The formatted post will be placed on your clipboard and saved to a `.txt` file in the same directory.

--- a/format_linkedin_post.py
+++ b/format_linkedin_post.py
@@ -1,0 +1,56 @@
+import re
+from pathlib import Path
+
+try:
+    import pyperclip
+except ImportError:
+    pyperclip = None
+
+# Mapping A-Z/a-z to their LinkedIn-friendly Unicode bold characters
+BOLD_MAP = {chr(i + 65): chr(0x1D400 + i) for i in range(26)}
+BOLD_MAP.update({chr(i + 97): chr(0x1D41A + i) for i in range(26)})
+
+# Mapping A-Z/a-z to their LinkedIn-friendly Unicode italic characters
+ITALIC_MAP = {chr(i + 65): chr(0x1D434 + i) for i in range(26)}
+ITALIC_MAP.update({chr(i + 97): chr(0x1D44E + i) for i in range(26)})
+
+
+def convert_markdown_to_linkedin_unicode(text: str) -> str:
+    """Convert markdown style **bold** and *italic* (or _italic_) to LinkedIn Unicode variants."""
+
+    def bold_repl(match: re.Match) -> str:
+        return "".join(BOLD_MAP.get(ch, ch) for ch in match.group(1))
+
+    def italic_repl(match: re.Match) -> str:
+        return "".join(ITALIC_MAP.get(ch, ch) for ch in match.group(1))
+
+    # Bold first, then italics so nested markers don't conflict
+    text = re.sub(r"\*\*(.+?)\*\*", bold_repl, text)
+    text = re.sub(r"\*(.+?)\*", italic_repl, text)
+    text = re.sub(r"_(.+?)_", italic_repl, text)
+    return text
+
+
+# The script reads your LinkedIn post from the clipboard when run
+POST_DRAFT = ""
+
+
+def main() -> None:
+    if not pyperclip:
+        print("pyperclip is not installed. Install it to use the clipboard features.")
+        return
+    global POST_DRAFT
+    POST_DRAFT = pyperclip.paste()
+    post_draft = POST_DRAFT
+    formatted = convert_markdown_to_linkedin_unicode(post_draft.strip())
+    first_paragraph = post_draft.strip().split("\n\n")[0]
+    sanitized = re.sub(r"[^A-Za-z0-9 _-]", "", first_paragraph)[:50].strip()
+    filename = "_".join(sanitized.split()) or "linkedin_post"
+    Path(f"{filename}.txt").write_text(formatted, encoding="utf-8")
+
+    pyperclip.copy(formatted)
+    print(f"Formatted post copied to clipboard and saved to {filename}.txt")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyperclip


### PR DESCRIPTION
## Summary
- update README usage instructions
- pull LinkedIn post text from clipboard
- support `_italic_` syntax

## Testing
- `python -m py_compile format_linkedin_post.py`
- `python format_linkedin_post.py` *(fails: pyperclip not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871967c49dc833083c82551d43f7f54